### PR TITLE
Mejora atendiendo a los comentarios anteriores.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/altipla-sites/cli
 go 1.14
 
 require (
+	github.com/google/go-github v17.0.0+incompatible
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
 	libs.altipla.consulting v1.79.0

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,9 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/internal/commands/cmd_clone.go
+++ b/internal/commands/cmd_clone.go
@@ -1,14 +1,81 @@
 package commands
 
 import (
+	"context"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/google/go-github/github"
 	"github.com/spf13/cobra"
+	"libs.altipla.consulting/errors"
 )
+
+var org string
+var pattern string
 
 var cmdClone = &cobra.Command{
 	Use:     "clone",
 	Short:   "Clona uno o varios proyectos en local",
 	Example: "sites clone",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		var repositoryNames []string
+		var dir []string
+
+		//***LEER PROYECTOS DE LA ORG***
+		client := github.NewClient(nil)
+
+		opt := &github.RepositoryListByOrgOptions{Type: "public"}
+		repos, _, err := client.Repositories.ListByOrg(context.Background(), org, opt)
+		if err != nil {
+			log.Fatal(errors.Stack(err))
+			return err
+		}
+
+		for _, repo := range repos {
+			repositoryNames = append(repositoryNames, *repo.Name)
+		}
+
+		//***LEER EL DIRECTORIO*** (y guardamos los nombres en dir)
+		path, err := os.Getwd()
+		if err != nil {
+			log.Fatal(errors.Stack(err))
+			return err
+		}
+
+		files, err := ioutil.ReadDir(path)
+		if err != nil {
+			log.Fatal(errors.Stack(err))
+			return err
+		}
+
+		for _, f := range files {
+			dir = append(dir, f.Name())
+		}
+
+		//***COMPARAMOS DIRECTORIO Y REPOSITORIO***
+		for _, x := range repositoryNames {
+			if strings.HasPrefix(x, pattern) {
+				for _, y := range dir {
+					if x == y {
+						//si el proyecto se encuentra no hacemos nada
+						goto jump
+					}
+				}
+			}
+
+			//clonamos si no se encuentra en el directorio
+			if strings.HasPrefix(x, pattern) {
+				var path2 string = path + "/" + org + "/" + x
+				x = "https://github.com/" + org + "/" + x
+				com := exec.Command("git", "clone", x, path2)
+				com.Run()
+			}
+		jump:
+		}
+
 		return nil
 	},
 }

--- a/internal/commands/cmd_root.go
+++ b/internal/commands/cmd_root.go
@@ -7,10 +7,6 @@ import (
 func init() {
 	CmdRoot.AddCommand(cmdAutocomplete)
 	CmdRoot.AddCommand(cmdClone)
-	cmdClone.Flags().StringVarP(&org, "org", "o", "", "Organizacion de Github (requerido)")
-	cmdClone.MarkFlagRequired("org")
-	cmdClone.Flags().StringVarP(&pattern, "pattern", "p", "", "Prefijo de los proyectos a clonar (requerido)")
-	cmdClone.MarkFlagRequired("pattern")
 }
 
 var CmdRoot = &cobra.Command{

--- a/internal/commands/cmd_root.go
+++ b/internal/commands/cmd_root.go
@@ -7,6 +7,10 @@ import (
 func init() {
 	CmdRoot.AddCommand(cmdAutocomplete)
 	CmdRoot.AddCommand(cmdClone)
+	cmdClone.Flags().StringVarP(&org, "org", "o", "", "Organizacion de Github (requerido)")
+	cmdClone.MarkFlagRequired("org")
+	cmdClone.Flags().StringVarP(&pattern, "pattern", "p", "", "Prefijo de los proyectos a clonar (requerido)")
+	cmdClone.MarkFlagRequired("pattern")
 }
 
 var CmdRoot = &cobra.Command{


### PR DESCRIPTION
Elimina los comentarios en el código.
Sustituye la sentencia goto.
Cambia la forma de tratar los errores.
Las etiquetas del comando clone ahora están implementadas en cmd_clone.